### PR TITLE
不返回查询条件错误原因

### DIFF
--- a/src/main/scala/com/kunyandata/backtesting/parser/Rules.scala
+++ b/src/main/scala/com/kunyandata/backtesting/parser/Rules.scala
@@ -292,12 +292,12 @@ object Rules {
       case "查看热度连续x天超过x" => (15005, s"${queryNumbers(0)},${queryNumbers(1)},${Int.MaxValue}")
       case "查看热度连续x天以上超过x" => (15005, s"${queryNumbers(0)},${queryNumbers(1)},${Int.MaxValue}")
 
-      case _ => (-1, s"查询条件错误“$query”：条件不存在或存在非法字符")
+      case _ => (-1, query)
     }
 
     resultTemp._2.startsWith("error:") match {
 
-      case true => (-1, s"查询条件错误“$query”：${resultTemp._2.replace("error:", "")}")
+      case true => (-1, query)
       case _ => resultTemp
     }
   }


### PR DESCRIPTION
(解决的bug和新增的特性至少要填写一项)
解决的bug:

新增的特性:不返回查询条件错误原因

补充:

